### PR TITLE
Bump PowerModels compat to 0.20, 0.21

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 PowerModels = "c36e90e8-916a-50a6-bd94-075b64ef4655"
 
 [compat]
-PowerModels = "~0.18, ~0.19"
+PowerModels = "~0.18, ~0.19, ~0.20, ~0.21"
 julia = "^1"
 
 [extras]


### PR DESCRIPTION
This PR bumps the PowerModels compat to include versions v0.20 and v0.21, in addition to v0.18 and v0.19