### PR TITLE
better error messages in pglib_buscount

### DIFF
--- a/src/PGLib.jl
+++ b/src/PGLib.jl
@@ -109,7 +109,7 @@ function _find_pglib_case(name::AbstractString, path::AbstractString)
 end
 
 """
-    `nbuses(name::AbstractString)`
+    `pglib_buscount(name::AbstractString)`
 
     Return the number of buses, as indicated by the filename. The filename
     should be the basename of the `.m` file, e.g. one of the strings returned
@@ -119,17 +119,16 @@ end
 function pglib_buscount(name::AbstractString)
     pglib_prefix = "pglib_opf_case"
     preflen = length(pglib_prefix)
-    prefix = name[1:preflen]
-    case_name = name[preflen+1:end]
-    if prefix != pglib_prefix
-        @error "filename is missing the prefix \"pglib_opf_case\""
+    if preflen > length(name) || name[1:preflen] != pglib_prefix
+        error("filename is missing the prefix \"pglib_opf_case\"")
     end
+    case_name = name[preflen+1:end]
     digit_len = 0
     while digit_len + 1 <= length(case_name) && isdigit(case_name[digit_len + 1])
         digit_len += 1
     end
     if digit_len == 0
-        @error "Invalid filename $name. Name must have format \"pglib_opf_case[0-9]+*\"."
+        error("Invalid filename $name. Name must have format \"pglib_opf_case[0-9]+*\".")
     end
     return parse(Int, case_name[1:digit_len])
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,4 +35,9 @@ case_sad = parse_file(joinpath("./pglib_opf_case3_lmbd__sad.m"))
         @test pglib_buscount("pglib_opf_case3_lmbd.m") == 3
         @test pglib_buscount("pglib_opf_case2736sp_k.m") == 2736
     end
+
+    @testset "test bad names" begin
+        @test_throws "filename is missing the prefix" pglib_buscount("CASE123")
+        @test_throws "Invalid filename pglib_opf_caseonehundred" pglib_buscount("pglib_opf_caseonehundred")
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,7 +37,7 @@ case_sad = parse_file(joinpath("./pglib_opf_case3_lmbd__sad.m"))
     end
 
     @testset "test bad names" begin
-        @test_throws "filename is missing the prefix" pglib_buscount("CASE123")
-        @test_throws "Invalid filename pglib_opf_caseonehundred" pglib_buscount("pglib_opf_caseonehundred")
+        @test_throws ErrorException pglib_buscount("CASE123")
+        @test_throws ErrorException pglib_buscount("pglib_opf_caseonehundred")
     end
 end


### PR DESCRIPTION
I used `@error` instead of `error`, leading to confusing error messages if an invalid string was passed to `pglib_buscount`. This also fixes the name of the function shown in the docstring.